### PR TITLE
chore: Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "git+https://github.com/chenshuai2144/github-contributors-list"
   },
   "peerDependencies": {
-    "react": "16.x"
+    "react": ">=16.0.0"
   },
   "devDependencies": {
     "father": "^2.16.0",


### PR DESCRIPTION
```
npm WARN @qixian.cs/github-contributors-list@1.0.5 requires a peer of react@16.x but none is installed. You must install peer dependencies yourself.
```

close https://github.com/ant-design/ant-design/issues/32386